### PR TITLE
Fix project name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 dosotroyah
 ==========
 
-desotroyah
+dosotroyah


### PR DESCRIPTION
## Summary
- fix project name typo in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68928ef2dce4832a80ce1b78ce0748e8